### PR TITLE
Move breadcrumb separator to list item instead of within anchor

### DIFF
--- a/styles/navigation/mod.css
+++ b/styles/navigation/mod.css
@@ -122,7 +122,7 @@ nav > ol {
   flex-wrap: wrap;
 }
 
-nav > ol > li:not(:last-child) > a::after {
+nav > ol > li:not(:last-child):has(>a)::after {
   display: inline-block;
   margin: 0 .25rem;
   color: var(--default);


### PR DESCRIPTION
The existing navigation/breadcrumb styling adds the separator to the anchor itself which goes against the grain when it comes to standard breadcrumb behaviour across the web.

This changes it so that the separator i s added to the list item itself instead of to the anchor.

Before change:
![chrome_z2tkkvOPjm](https://github.com/lowlighter/matcha/assets/18017893/9af7a5c6-f809-407b-9259-0df47db29aa3)

After change:
![chrome_ZJ7l9mESi8](https://github.com/lowlighter/matcha/assets/18017893/7abf448f-0765-4762-8da9-20467ccad2f3)
