### PR TITLE
fix(details): visual sloppy

### DIFF
--- a/styles/collapsibles/mod.css
+++ b/styles/collapsibles/mod.css
@@ -12,6 +12,7 @@ summary {
   color: var(--accent);
   cursor: pointer;
   user-select: none;
+  border-radius: calc(var(--bd-radius) - 1px) calc(var(--bd-radius) - 1px) 0 0;
 }
 
 summary:hover {


### PR DESCRIPTION
Before:
<img width="462" alt="Снимок экрана 2024-05-26 в 19 02 02" src="https://github.com/lowlighter/matcha/assets/3195714/95ef2819-4d1f-4427-b6f9-4d3cba4cfe1d">

After:
<img width="478" alt="Снимок экрана 2024-05-26 в 19 02 11" src="https://github.com/lowlighter/matcha/assets/3195714/181d53f9-5456-4cf1-8eb2-924d70f5429a">

Why i use calc?
Without calc inner and outer radii does not equal
<img width="434" alt="Снимок экрана 2024-05-26 в 19 05 07" src="https://github.com/lowlighter/matcha/assets/3195714/f1a6cff3-14a0-4f45-a833-a3f033d32a89">

see more: https://css-tricks.com/public-service-announcement-careful-with-your-nested-border-radii/