### PR TITLE
feat: add togglable example schemes

### DIFF
--- a/app/build/html.ts
+++ b/app/build/html.ts
@@ -53,6 +53,13 @@ export async function html() {
     details.querySelector("code")!.innerHTML = syntax.highlight(code, { language: "html" }).value.trim()
     element.after(details)
   })
+  Array.from(document.querySelectorAll(".example:not([data-codeless]), .example[data-color-schemeable]")).forEach((_element) => {
+    const element = _element as unknown as HTMLElement
+    const tabs = document.createElement("menu") as unknown as HTMLMenuElement
+    tabs.classList.add("example-tabs")
+    tabs.innerHTML = `<li class="color-scheme">${document.querySelector(".color-scheme")!.innerHTML}</li>`
+    element.before(tabs)
+  })
   // Generate table of contents
   const nav = [] as string[]
   Array.from(document.querySelectorAll("main > section")).forEach((_element) => {

--- a/app/mod.css
+++ b/app/mod.css
@@ -240,6 +240,7 @@ main > section > :is(h1)[id]:not([id="matcha"]) {
   border: 1px solid var(--bd-muted);
   border-radius: var(--bd-radius);
   box-sizing: border-box;
+  transition: all var(--tr-duration);
 }
 
 .example:not([data-codeless]) {
@@ -268,6 +269,28 @@ main > section > :is(h1)[id]:not([id="matcha"]) {
   margin-top: 1rem;
   display: block;
   text-align: left;
+}
+
+/** Example tabs */
+.example-tabs {
+  justify-content: end;
+  margin-bottom: 0;
+  border-bottom: none;
+  margin: .5rem 0 .25rem;
+}
+
+.example-tabs > li {
+  margin: 0;
+}
+
+.example-tabs > li:hover {
+  background: var(--bg-accent);
+  color: var(--accent);
+}
+
+.example-tabs svg {
+  display: none;
+  fill: currentColor;
 }
 
 /* Additional example styles */

--- a/app/mod.html
+++ b/app/mod.html
@@ -19,7 +19,7 @@
       <h1 class="success">matcha.css</h1>
       <nav>
         <menu>
-          <li><a href="#" onclick="event.preventDefault();document.querySelector('html').dataset.colorScheme = (document.querySelector('html').dataset.colorScheme ?? (matchMedia('(prefers-color-scheme: dark)') ? 'dark' : 'light')) === 'light' ? 'dark' : 'light'">
+          <li><a href="#" onclick="event.preventDefault();document.querySelector('html').dataset.colorScheme = (document.querySelector('html').dataset.colorScheme ?? (matchMedia('(prefers-color-scheme: dark)') ? 'dark' : 'light')) === 'light' ? 'dark' : 'light'" class="color-scheme">
             <svg class="light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M8 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8Zm0-1.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm5.657-8.157a.75.75 0 0 1 0 1.061l-1.061 1.06a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 1 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0ZM8 0a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm13 0a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8Zm-8 5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13Zm3.536-1.464a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-1.06-1.06a.75.75 0 0 1 0-1.06Z"></path></svg>
             <svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Zm1.616 1.945a7 7 0 0 1-7.678 7.678 5.499 5.499 0 1 0 7.678-7.678Z"></path></svg>
           </a></li>
@@ -334,5 +334,19 @@
         </menu>
       </nav>
     </footer>
+    <script>
+      {
+        const prefers = matchMedia('(prefers-color-scheme: dark)') ? 'dark' : 'light'
+        document.querySelectorAll(".example-tabs li.color-scheme").forEach(element => {
+          element.querySelector(`svg.${prefers}`).style.display = "block"
+          element.addEventListener("click", event => {
+            const example = element.parentNode.nextSibling
+            example.dataset.colorScheme = (example.dataset.colorScheme ?? prefers) === 'light' ? 'dark' : 'light'
+            element.querySelector("svg.light").style.display = example.dataset.colorScheme === 'light' ? "block" : "none"
+            element.querySelector("svg.dark").style.display = example.dataset.colorScheme === 'dark' ? "block" : "none"
+          });
+        })
+      }
+    </script>
   </body>
 </html>

--- a/styles/@istanbul-coverage/mod.html
+++ b/styles/@istanbul-coverage/mod.html
@@ -3,7 +3,7 @@
   <em>matcha.css</em> provides classes that respect <a href="https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme"><code data-hl="css">@media (prefers-color-scheme)</code></a> and are compatible with <a href="https://istanbul.js.org/" target="_blank">istanbul.js</a>-like coverage reports.
 </p>
 <section>
-  <div class="example istanbul-coverage-report" data-codeless>
+  <div class="example istanbul-coverage-report" data-codeless data-color-schemeable>
     <div class="table-responsive"><table class="coverage">
       <tbody><tr>
         <td class="line-count quiet"><pre><a href="#">01</a>

--- a/styles/sectioning/html.html
+++ b/styles/sectioning/html.html
@@ -14,6 +14,9 @@
       </ul>
     </li>
   </ul>
+  <p>
+    Note that <code data-hl="css">[data-color-scheme]</code> can be applied to any element to selectively force a color scheme.
+  </p>
   <!--/styles/sectioning/body.html-->
   <!--/styles/sectioning/main.html-->
 </section>

--- a/styles/sectioning/mod.css
+++ b/styles/sectioning/mod.css
@@ -10,6 +10,11 @@ body {
   line-height: 1.5;
 }
 
+[data-color-scheme] {
+  background: var(--bg-default);
+  color: var(--default);
+}
+
 main, header {
   margin: 0 0 1rem;
 }


### PR DESCRIPTION
This add a small button above example to toggle the color scheme without doing so globally.
Additionnally you can now set `[data-color-scheme]` to selectively force color schem on elements

![image](https://github.com/lowlighter/matcha/assets/22963968/a7604d97-9c26-43f0-9955-627876185992)
