### PR TITLE
fix(forms): fix button utilities specificity issue

### DIFF
--- a/styles/forms/mod.css
+++ b/styles/forms/mod.css
@@ -223,8 +223,8 @@ button[type]:not([type="button"]), input:is([type="submit"],[type="reset"]) {
   border-color: currentColor;
 }
 
-:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):hover,
-:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):active {
+:where(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):hover,
+:where(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):active {
   border-color: transparent;
   background: var(--accent);
   color: var(--light);


### PR DESCRIPTION
## Bug description
I noticed that buttons with utility color classes turn blue on `:hover`.

![Hovering on buttons with utility colors classes](https://github.com/user-attachments/assets/d5b909d2-32df-41b2-ae18-b9be313e6d17)

If the example below is the expected behavior of these buttons, I believe this is a specificity bug:

![GravacaodeTela2024-07-14as13 23 06-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/1abdd037-426e-48b0-9295-b33c2b7bb21d)

Using the `.default` variant as an example, this is the CSS with the intended behavior:
```css
button.default:not(:disabled):active,button.default:not(:disabled):hover {
    background: var(--default);
    color: var(--contrast)
}
```

It produces a 0,3,1 specificity and it is being overridden by this selector, which also has a specificity of 0.3.1 because its declared further on the code.

```css
:is(button,input:is([type=submit],[type=reset],[type=button],[type=image])):not(:disabled):active,:is(button,input:is([type=submit],[type=reset],[type=button],[type=image])):not(:disabled):hover {
    border-color: transparent;
    background: var(--accent);
    color: var(--light)
}
```

<br />

## Proposal - Using an :where selector

> [!NOTE]  
> This solution is **agnostic and non-obstrusive** and have [sufficient browser support](https://caniuse.com/?search=%3Awhere). Ran `deno task fmt` on this code.

In `styles/forms/mod.css`, L226

```css
:where(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):hover,
:where(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):active {
  border-color: transparent;
  background: var(--accent);
  color: var(--light);
}
```


Closes #42 