### PR TITLE
feat(proposal): use where selector to manage class specificity

### DIFF
--- a/styles/forms/mod.css
+++ b/styles/forms/mod.css
@@ -7,11 +7,16 @@ form {
   background: var(--bg-muted);
 }
 
-:is(form, label):last-child {
+/* Specificity 0,1,1 to 0,0,0 */ 
+:where(form:last-child, label:last-child) {
   margin-bottom: 0;
 }
 
-form code {
+/* Specificity 0,0,2 to 0,0,1
+It refers to a inner children, if the specificity is reduced
+further it may collide with CSS resets
+*/ 
+form :where(code) {
   background: var(--bg-subtle);
 }
 
@@ -35,33 +40,52 @@ label {
   margin: 0 0 1rem;
 }
 
-label > small {
+/* Specificity 0,0,2 to 0,0,1
+It refers to a inner children, if the specificity is reduced
+further it may collide with CSS resets
+*/ 
+label > :where(small) {
   color: var(--muted);
 }
 
-label > small:first-child::after,
-label > small:first-child::before {
+/* Specificity 0,1,3 to 0,0,2
+Since :where does't support `::before` and `::after`, it
+couldn't be reduced further
+*/ 
+label > :where(small:first-child)::after,
+label > :where(small:first-child)::before {
   content: "\A";
   white-space: pre;
 }
 
-label:has(> :is(input, textarea, button)) {
+/* Specificity 0,0,2 to 0,0,1 */ 
+label:has(> :where(input, textarea, button)) {
   cursor: pointer;
 }
 
-label:has(> :is(input, textarea, select, button):disabled) {
+/* Specificity 0,1,2 to 0,1,1
+IMHO pseudoclasses must preserve higher specificity
+*/ 
+label:has(> :where(input, textarea, select, button):disabled) {
   color: var(--muted);
   cursor: not-allowed;
 }
 
-label:has(> :is(input, textarea, select):required)::before {
+/* Specificity 0,1,3 to 0,1,2
+IMHO pseudoclasses must preserve higher specificity
+*/ 
+label:has(> :where(input, textarea, select):required)::before {
   position: absolute;
   left: -.6rem;
   color: var(--danger);
   content: "*";
 }
 
-label:has(> textarea) {
+/* Specificity 0,0,2 to 0,0,1
+It refers to a inner children, if the specificity is reduced
+further it may collide with CSS resets
+*/ 
+label:has(> :where(textarea)) {
   display: block;
 }
 
@@ -94,11 +118,13 @@ textarea {
   resize: none;
 }
 
-:is(textarea, select):hover {
+/* Specificity 0,1,1 to 0,1,0 */ 
+:where(textarea, select):hover {
   border-color: var(--accent);
 }
 
-:is(input, textarea, select):disabled {
+/* Specificity 0,1,1 to 0,1,0 */ 
+:where(input, textarea, select):disabled {
   background-color: var(--bg-muted);
   cursor: not-allowed;
 }
@@ -115,17 +141,20 @@ input {
   appearance: none;
 }
 
-input:not(:disabled):hover {
+/* Specificity 0,2,1 to 0,1,0 */ 
+:where(input:not(:disabled)):hover {
   border-color: var(--accent);
 }
 
-input:not([type="radio"],[type="checkbox"]) {
+/* Specificity 0,1,1 to 0,0,1 */ 
+input:where(:not([type="radio"],[type="checkbox"])) {
   position: relative;
   min-height: 1.5rem;
   padding: .25rem .5rem;
 }
 
-input:is([type="radio"],[type="checkbox"]), input[type="checkbox"]::before {
+/* Specificity 0,1,1 to 0,0,1 */ 
+input:where([type="radio"],[type="checkbox"]), input:where([type="checkbox"])::before {
   display: inline-block;
   width: 1rem;
   height: 1rem;
@@ -133,26 +162,31 @@ input:is([type="radio"],[type="checkbox"]), input[type="checkbox"]::before {
   vertical-align: middle;
 }
 
-input[type="checkbox"] {
+/* Specificity 0,1,1 to 0,0,1 */
+input:where([type="checkbox"]) {
   border-radius: 0;
 }
 
-input[type="radio"] {
+/* Specificity 0,1,1 to 0,0,1 */
+input:where([type="radio"]) {
   border-width: 2px;
   border-radius: 50%;
 }
 
-input[type="radio"]:checked {
+/* Specificity 0,2,1 to 0,1,1 */
+input:where([type="radio"]):checked {
   border-width: .25rem;
   border-color: var(--accent);
 }
 
-input[type="checkbox"]:checked {
+/* Specificity 0,2,1 to 0,1,1 */
+input:where([type="checkbox"]):checked {
   border-color: var(--accent);
   background: var(--accent);
 }
 
-input[type="checkbox"]:checked::before {
+/* Specificity 0,2,2 to 0,1,2 */
+input:where([type="checkbox"]):checked::before {
   position: absolute;
   margin: 0;
   background: var(--light);
@@ -161,15 +195,18 @@ input[type="checkbox"]:checked::before {
   mask-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOSIgdmlld0JveD0iMCAwIDEyIDkiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTEuNzgwMyAwLjIxOTYyNUMxMS45MjEgMC4zNjA0MjcgMTIgMC41NTEzMDUgMTIgMC43NTAzMTNDMTIgMC45NDkzMjEgMTEuOTIxIDEuMTQwMTkgMTEuNzgwMyAxLjI4MUw0LjUxODYgOC41NDA0MkM0LjM3Nzc1IDguNjgxIDQuMTg2ODIgOC43NiAzLjk4Nzc0IDguNzZDMy43ODg2NyA4Ljc2IDMuNTk3NzMgOC42ODEgMy40NTY4OSA4LjU0MDQyTDAuMjAxNjIyIDUuMjg2MkMwLjA2ODkyNzcgNS4xNDM4MyAtMC4wMDMzMDkwNSA0Ljk1NTU1IDAuMDAwMTE2NDkzIDQuNzYwOThDMC4wMDM1NTIwNSA0LjU2NjQzIDAuMDgyMzg5NCA0LjM4MDgxIDAuMjIwMDMyIDQuMjQzMjFDMC4zNTc2NjUgNC4xMDU2MiAwLjU0MzM1NSA0LjAyNjgxIDAuNzM3OTcgNC4wMjMzOEMwLjkzMjU4NCA0LjAxOTk0IDEuMTIwOTMgNC4wOTIxNyAxLjI2MzM0IDQuMjI0ODJMMy45ODc3NCA2Ljk0ODM1TDEwLjcxODYgMC4yMTk2MjVDMTAuODU5NSAwLjA3ODk5MjMgMTEuMDUwNCAwIDExLjI0OTUgMEMxMS40NDg1IDAgMTEuNjM5NSAwLjA3ODk5MjMgMTEuNzgwMyAwLjIxOTYyNVoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=");
 }
 
-input:is([type="radio"],[type="checkbox"]):disabled {
+/* Specificity 0,2,1 to 0,1,1 */
+input:where([type="radio"],[type="checkbox"]):disabled {
   background-color: var(--bd-muted);
 }
 
-input[type="checkbox"]:disabled {
+/* Specificity 0,2,1 to 0,1,1 */
+input:where([type="checkbox"]):disabled {
   border-color: transparent;
 }
 
-input[type="range"] {
+/* Specificity 0,1,1 to 0,0,1 */
+input:where([type="range"]) {
   height: .5rem;
   border: transparent;
   margin: .75rem 0;
@@ -178,7 +215,8 @@ input[type="range"] {
   background: var(--bg-subtle);
 }
 
-input[type="file"]::file-selector-button {
+/* Specificity 0,1,2 to 0,0,2 */
+input:where([type="file"])::file-selector-button {
   border: 1px solid var(--bd-muted);
   border-radius: var(--bd-radius);
   background: transparent;
@@ -186,13 +224,17 @@ input[type="file"]::file-selector-button {
   font: inherit;
 }
 
-input[type="file"]:hover::file-selector-button {
+/* Specificity 0,2,2 to 0,1,2
+IMHO pseudoclasses must preserve higher specificity
+*/
+input:where([type="file"]):hover::file-selector-button {
   background: var(--accent);
   color: var(--light);
 }
 
 /* Buttons */
-button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"]) {
+/* Specificity 0,1,1 to 0,0,1 */
+button, input:where([type="submit"],[type="reset"],[type="button"],[type="image"]) {
   display: inline-block;
   padding: .25rem .75rem;
   margin: .25rem .125rem;
@@ -202,36 +244,44 @@ button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"]) 
   transition: background var(--tr-duration), color var(--tr-duration), filter var(--tr-duration);
 }
 
-input:is([type="image"],[type="file"],[type="color"]) {
+/* Specificity 0,1,1 to 0,0,1 */
+input:where([type="image"],[type="file"],[type="color"]) {
   padding: .25rem;
 }
 
-:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):disabled {
+/* Specificity 0,2,1 to 0,1,1 */
+:is(button, input:where([type="submit"],[type="reset"],[type="button"],[type="image"])):disabled {
   cursor: not-allowed;
   opacity: .5;
 }
 
-:is(button, input)[type="reset"] {
+/* Specificity 0,1,1 to 0,0,1 */
+:is(button, input):where([type="reset"]) {
   color: var(--danger);
 }
 
-:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):active {
+/* Specificity 0,3,1 to 0,1,0 */
+:where(button:not(:disabled)):active,
+:where(input:is([type="submit"],[type="reset"],[type="button"],[type="image"]):not(:disabled)):active {
   filter: brightness(80%);
 }
 
-button[type]:not([type="button"]), input:is([type="submit"],[type="reset"]) {
+/* Specificity 0,2,1 to 0,1,0 */
+:where(button[type]):not([type="button"]),
+input:where([type="submit"],[type="reset"]) {
   border-color: currentColor;
 }
 
-:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):hover,
-:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled):active {
+/* Specificity 0,3,1 to 0,1,0 */
+:where(:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled)):hover,
+:where(:is(button, input:is([type="submit"],[type="reset"],[type="button"],[type="image"])):not(:disabled)):active {
   border-color: transparent;
   background: var(--accent);
   color: var(--light);
 }
 
-:is(button, input)[type="reset"]:not(:disabled):hover,
-:is(button, input)[type="reset"]:not(:disabled):active {
+/* Specificity 0,3,1 to 0,1,0 */
+:where(button, input)[type="reset"]:where(:not(:disabled):active, :not(:disabled):hover) {
   border-color: transparent;
   background: var(--danger);
   color: var(--light);


### PR DESCRIPTION
## Bug description
I noticed that buttons with utility color classes turn blue on `:hover`.

![Hovering on buttons with utility colors classes](https://github.com/user-attachments/assets/d5b909d2-32df-41b2-ae18-b9be313e6d17)

If the example below is the expected behavior of these buttons, I believe this is a specificity bug:

![GravacaodeTela2024-07-14as13 23 06-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/1abdd037-426e-48b0-9295-b33c2b7bb21d)

Using the `.default` variant as an example, this is the CSS with the intended behavior:
```css
button.default:not(:disabled):active,button.default:not(:disabled):hover {
    background: var(--default);
    color: var(--contrast)
}
```

It produces a 0,3,1 specificity and it is being overridden by this selector, which also has a specificity of 0.3.1 because its declared further on the code.

```css
:is(button,input:is([type=submit],[type=reset],[type=button],[type=image])):not(:disabled):active,:is(button,input:is([type=submit],[type=reset],[type=button],[type=image])):not(:disabled):hover {
    border-color: transparent;
    background: var(--accent);
    color: var(--light)
}
```

<br />

### Proposal - Using an :where selector as an architectural axiom

> [!NOTE]  
> This solution is **agnostic and non-obstrusive** and have [sufficient browser support](https://caniuse.com/?search=%3Awhere) but it will require a more comprehensive change and may potentially lead to a major version increment.

Every CSS subdirectory acts as a module that serves both base styles and utility-oriented styles. For base styles related directly to HTML elements, you may want to maintain the lowest specificity possible to avoid collision with utility styles.
I suggest [Elad Shechter approach on CSS Reset](https://elad2412.github.io/the-new-css-reset/). This ensures that every "base" styles will be safely overridden.

**Pros**
For better composability and overriding of classes, I tried to maintain specificity levels at 0,0,1 for base styles and 0,1,x for states and pseudo to reduce the chances of overriding base styles by resets or subsequent modules.

**Cons**
This solution results in more complex selectors, and consequently slower, which within the scope of this library would not affect most users. However, it would complicate debugging and maintenance.

Closes #42 