### PR TITLE
fix: monospace class use --ft-mono

### DIFF
--- a/styles/@utilities/classes.html
+++ b/styles/@utilities/classes.html
@@ -55,7 +55,7 @@
           <code data-hl="css">.justified</code> sets <code data-hl="css">text-align: justify;</code>
         </li>
         <li>
-          <code data-hl="css">.monospace</code> sets <code data-hl="css">font-family: var(--mono);</code>
+          <code data-hl="css">.monospace</code> sets <code data-hl="css">font-family: var(--ft-mono);</code>
         </li>
       </ul>
     </li>

--- a/styles/@utilities/mod.css
+++ b/styles/@utilities/mod.css
@@ -208,7 +208,7 @@
 }
 
 .monospace {
-  font-family: var(--mono);
+  font-family: var(--ft-mono);
 }
 
 /* Font size */


### PR DESCRIPTION
Use `--ft-mono` instead of `mono` in the `monospace` class (and in the documentation).
This is a fix for issue #60 .