### PR TITLE
Fix incorrect usage of `:host`

### DIFF
--- a/styles/@root/mod.css
+++ b/styles/@root/mod.css
@@ -137,7 +137,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-color-scheme="light"]), :host:not([data-color-scheme="light"]) {
+  :root:not([data-color-scheme="light"]), :host(:not([data-color-scheme="light"])) {
     /* Colors */
     --default: var(--dark-default);
     --subtle: var(--dark-subtle);

--- a/styles/@syntax-highlighting/mod.css
+++ b/styles/@syntax-highlighting/mod.css
@@ -21,7 +21,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-color-scheme="light"]), :host:not([data-color-scheme="light"]) {
+  :root:not([data-color-scheme="light"]), :host(:not([data-color-scheme="light"])) {
     --comment: #8b949e;
     --function: #d2a8ff;
     --language: #79c0ff;


### PR DESCRIPTION
Use `:host(:not(...))` instead of `:host:not(...)` according to <https://drafts.csswg.org/css-scoping/#host-selector>. Otherwise the theme won't follow the system when matcha.css is used **only** inside the shadow DOM.